### PR TITLE
properly read --compilerOptions from cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "bin": "lib/index.js",
   "scripts": {
-    "test": "tslint index.ts && tsc && node lib/index.js --config=spec/jasmine.json spec/jasmine-ts.spec.ts",
+    "test": "./node_modules/.bin/tslint index.ts && tsc && node lib/index.js --config=spec/jasmine.json spec/jasmine-ts.spec.ts --compilerOptions='{\"allowJs\": true}'",
     "prepublishOnly": "tsc"
   },
   "repository": {

--- a/spec/inc.js
+++ b/spec/inc.js
@@ -1,0 +1,2 @@
+
+module.exports = true

--- a/spec/jasmine-ts.spec.ts
+++ b/spec/jasmine-ts.spec.ts
@@ -1,7 +1,14 @@
+import "jasmine"
+import * as js from "./inc.js"
+
 describe("jasmine-ts", () => {
 
   it("should work with TypeScript files", () => {
     expect(true).toBe(true);
   });
+
+  it("should parse --compilerOptions properly", () => {
+    expect(js).toBe(true);
+  })
 
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import * as fs from "fs";
 import * as path from "path";
-import { register } from "ts-node/dist";
+import { register, parse } from "ts-node/dist";
 import { argv } from "yargs";
 
 const TS_NODE_OPTIONS = [
@@ -19,7 +19,14 @@ const TS_NODE_OPTIONS = [
   "compilerOptions",
 ];
 
-const tsNodeOptions = Object.assign({}, ...TS_NODE_OPTIONS.map((option) => argv[option] && {[option]: argv[option]}));
+const tsNodeOptions = Object.assign({}, ...TS_NODE_OPTIONS.map((option) => {
+  if (argv[option]) {
+    return (option === "compilerOptions")
+      ? {compilerOptions: parse(argv[option])}
+      : {[option]: argv[option]}
+  }
+}));
+
 register(tsNodeOptions);
 
 const Jasmine = require("jasmine");


### PR DESCRIPTION
**Context:**
`ts-node` expects `compilerOptions` to be formatted as JSON when used from CLI, example:
```sh
ts-node --compilerOptions '{"allowJs": true}'
```
But it expects a JavaScript object when provided by using the API, example:
```js
import { register } from 'ts-node'
register({compilerOptions: {allowJs: true}})
```
**Problem:**
`jasmine-ts` allows passing CLI args to `ts-node` but actually `compilerOptions` is passed as string, not as an object that is what `ts-node` expects.

**Proposal:**
So, what this PR does is to properly parse `compilerOptions` provided to `jasmine-ts` through CLI before to be passed to `ts-node` API.

--Tests included.
