### PR TITLE
Filter disables the file argument support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,6 @@ if (configJSON) {
   initReporters(config);
 }
 
-const commandOptions = process.argv.slice(2).filter((option) => option.indexOf(configPath) >= 0);
+const commandOptions = process.argv.slice(2);
 
 command.run(jasmine, commandOptions);


### PR DESCRIPTION
At line 63, you filtered the arguments and only the --configPath argument is available. This causes to loose the functionality to pass some file or files to test them. It is related to the issue #33