### PR TITLE
chore(dependencies): update ts-node dependencies to avoid false warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Example `package.json`:
 
 You still need to install the typings for jasmine to make the typescript-compiler happy about your specs:
 
-TypeScript 2:
+TypeScript >= 2:
 ```
 npm i -D @types/jasmine
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-ts",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Execute jasmine with ts-node",
   "main": "lib/index.js",
   "bin": "lib/index.js",
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "jasmine": ">=3.4",
-    "ts-node": ">=3.2.0 <=8",
+    "ts-node": ">=3.2.0 <9",
     "typescript": ">=3.5.2"
   },
   "devDependencies": {
@@ -44,7 +44,7 @@
     "jasmine": ">=3.4",
     "jasmine-spec-reporter": "^4.2.1",
     "rimraf": "^2.6.3",
-    "ts-node": ">=3.2.0 <=8",
+    "ts-node": ">=3.2.0 <9",
     "tslint": "^5.17.0",
     "typescript": ">=3.5.2"
   },


### PR DESCRIPTION
ts-node `<=8` throws a warning when using versions higher than 8.0.0.
to keep the same structure, the PR proposes `9`

The is also a small change on the readme and a bump on version on package.json.