### PR TITLE
fix: reworked the CLI parameter processing

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,13 +8,12 @@ on:
 jobs:
   test:
 
-    name: Test on node ${{ matrix.node-version }} and ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Test on node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
         node-version: [12, 14, 15]
-        os: [ubuntu-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,12 +8,13 @@ on:
 jobs:
   test:
 
-    name: Test on node ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
+    name: Test on node ${{ matrix.node-version }} and ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         node-version: [12, 14, 15]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
       "devDependencies": {
         "@types/jasmine": "^3.6.3",
         "@types/node": "^14.14.25",
-        "@types/yargs": "^16.0.0",
+        "@types/yargs": "^16.0.1",
+        "dotenv": "^8.2.0",
         "jasmine": "^3.6.4",
         "jasmine-spec-reporter": "^7.0.0",
         "rimraf": "^3.0.2",
@@ -675,6 +676,15 @@
       "dependencies": {
         "is-obj": "^2.0.0"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3381,6 +3391,12 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
     },
     "dotgitignore": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "precompile": "rimraf lib",
     "compile": "tsc --project tsconfig.json",
     "lint": "tslint -p tsconfig.json",
-    "jasmineTs": "node lib/index.js --config=spec/jasmine.json spec/jasmine-ts.spec.ts --transpileOnly --compilerOptions='{\"allowJs\": true}' --fake-option",
+    "jasmineTs": "node lib/index.js --config=spec/jasmine.json spec/jasmine-ts.spec.ts",
     "test": "npm run lint && npm run compile && npm run jasmineTs",
     "prepublishOnly": "npm run compile",
     "release": "standard-version"
@@ -47,7 +47,8 @@
   "devDependencies": {
     "@types/jasmine": "^3.6.3",
     "@types/node": "^14.14.25",
-    "@types/yargs": "^16.0.0",
+    "@types/yargs": "^16.0.1",
+    "dotenv": "^8.2.0",
     "jasmine": "^3.6.4",
     "jasmine-spec-reporter": "^7.0.0",
     "rimraf": "^3.0.2",

--- a/spec/jasmine-ts.spec.ts
+++ b/spec/jasmine-ts.spec.ts
@@ -1,14 +1,195 @@
-import "jasmine"
-import * as js from "./inc.js"
+import {spawn} from "child_process";
+import * as path from "path";
 
 describe("jasmine-ts", () => {
 
-  it("should work with TypeScript files", () => {
-    expect(true).toBe(true);
+  it("should start with default parameters", async () => {
+    const result = await testJasmine();
+    expect(result.exitCode).toBe(1)
+    expect(result.output).toContain('No specs found')
   });
 
-  it("should parse --compilerOptions properly", () => {
-    expect(js).toBe(true);
+  it('should process simple ts file with default params', async () => {
+    const cwd = path.join(__dirname, 'test-cases', 'simple-ts-file')
+
+    const result = await testJasmine(['index.ts'], cwd);
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain('1 spec, 0 failures')
+  })
+
+  it('should process simple js file with default params', async () => {
+    const cwd = path.join(__dirname, 'test-cases', 'simple-js-file')
+
+    const result = await testJasmine(['index.js'], cwd);
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain('1 spec, 0 failures')
+  })
+
+  it('should work with jasmine.json', async () => {
+    const cwd = path.join(__dirname, 'test-cases', 'jasmine-json')
+
+    const result = await testJasmine(['--config=./jasmine.json'], cwd);
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain('1 spec, 0 failures')
+    expect(result.output).not.toContain('Randomized with seed')
+  })
+
+  it('should work --require with node_module', async () => {
+    const cwd = path.join(__dirname, 'test-cases', 'require')
+
+    const result = await testJasmine(['--require="dotenv/config"', 'node_module.spec.ts'], cwd);
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain('1 spec, 0 failures')
+  })
+
+  it('should work --require with relative file', async () => {
+    const cwd = path.join(__dirname, 'test-cases', 'require')
+
+    const result = await testJasmine(['--require="./require-file.js"', 'file.spec.ts'], cwd);
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain('1 spec, 0 failures')
+  })
+
+  it('should work --require with relative file and node_modules', async () => {
+    const cwd = path.join(__dirname, 'test-cases', 'require')
+
+    const result = await testJasmine(['--require="./require-file.js"', '--require="dotenv/config"', 'file-and-node_module.spec.ts'], cwd);
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain('1 spec, 0 failures')
+  })
+
+  it('should work with --reporter', async () => {
+    const cwd = path.join(__dirname, 'test-cases', 'reporter')
+    const reporterPath = path.join(cwd, 'custom-reporter.js')
+
+    const result = await testJasmine([`--reporter="${reporterPath}"`, 'index.spec.ts'], cwd);
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain('Executed 1 of 1 spec\x1B[32m SUCCESS\x1B[39m in ')
+  })
+
+  it('should work with --project', async () => {
+    const cwd = path.join(__dirname, 'test-cases', 'project')
+    const projectPath = path.join(cwd, 'sub-dir', 'tsconfig.json')
+
+    const result = await testJasmine([`--project=${projectPath}`, 'index.spec.ts'], cwd);
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain('1 spec, 0 failures')
+  })
+
+  it('should work with --compiler-options', async () => {
+    const cwd = path.join(__dirname, 'test-cases', 'project')
+
+    const result = await testJasmine(['--compiler-options="{\\"allowJs\\":true, \\"checkJs\\":false}"', 'index.spec.ts'], cwd);
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain('1 spec, 0 failures')
+  })
+
+  it('should work with --color', async () => {
+    const cwd = path.join(__dirname, 'test-cases', 'simple-ts-file')
+
+    const result = await testJasmine(['--color', 'index.ts'], cwd);
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain('Started\n\x1B[32m.\x1B[0m\n\n\n')
+  })
+
+  it('should work with --no-color', async () => {
+    const cwd = path.join(__dirname, 'test-cases', 'simple-ts-file')
+
+    const result = await testJasmine(['--no-color', 'index.ts'], cwd);
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain('Started\n.\n\n\n')
+  })
+
+  it('should work with --stop-on-failure=false', async () => {
+    const cwd = path.join(__dirname, 'test-cases', 'stop-on-failure')
+    const reporterPath = path.join(cwd, 'custom-reporter.js')
+
+    const result = await testJasmine(
+      [
+        '--config=./jasmine.json',
+        '--stop-on-failure=false',
+        `--reporter="${reporterPath}"`,
+        'index.spec.ts'],
+      cwd);
+    expect(result.exitCode).toBe(1)
+    expect(result.output).toContain('✗ test case 1')
+    expect(result.output).toContain('✓ test case 2')
+  })
+
+  it('should work with --stop-on-failure=true', async () => {
+    const cwd = path.join(__dirname, 'test-cases', 'stop-on-failure')
+    const reporterPath = path.join(cwd, 'custom-reporter.js')
+
+    const result = await testJasmine(
+      [
+        '--config=./jasmine.json',
+        '--stop-on-failure=true',
+        `--reporter="${reporterPath}"`,
+        'index.spec.ts'],
+      cwd);
+    expect(result.exitCode).toBe(1)
+    expect(result.output).toContain('✗ test case 1')
+    expect(result.output).toContain('✗ test case 2')
+  })
+
+  it('should work with --fail-fast=false', async () => {
+    const cwd = path.join(__dirname, 'test-cases', 'fail-fast')
+    const reporterPath = path.join(cwd, 'custom-reporter.js')
+
+    const result = await testJasmine(
+      [
+        '--config=./jasmine.json',
+        '--fail-fast=false',
+        `--reporter="${reporterPath}"`,
+        'index.spec.ts'],
+      cwd);
+    expect(result.exitCode).toBe(1)
+    expect(result.output).toContain('✗ should fail')
+    expect(result.output).toContain('✓ should pass')
+  })
+
+  it('should work with --fail-fast=true', async () => {
+    const cwd = path.join(__dirname, 'test-cases', 'fail-fast')
+    const reporterPath = path.join(cwd, 'custom-reporter.js')
+
+    const result = await testJasmine(
+      [
+        '--config=./jasmine.json',
+        '--fail-fast=true',
+        `--reporter="${reporterPath}"`,
+        'index.spec.ts'],
+      cwd);
+    expect(result.exitCode).toBe(1)
+    expect(result.output).toContain('✗ should fail')
+    expect(result.output).not.toContain(' should pass')
+    expect(result.output).toContain('1 SKIPPED')
   })
 
 });
+
+function testJasmine(args: string[] = [], cwd?: string): Promise<any> {
+  return new Promise<any>((resolve) => {
+    const indexJsPath = path.join(__dirname, '..', 'lib', 'index.js')
+
+    const instance = spawn('node', [indexJsPath, ...args], {shell: true, cwd})
+    let outBuffer = Buffer.alloc(0);
+    instance.stdout.on('data', data => {
+      outBuffer = Buffer.concat([outBuffer, data])
+    })
+
+    instance.stderr.on('data', data => {
+      outBuffer = Buffer.concat([outBuffer, data])
+    })
+
+    instance.on('close', code => {
+      console.log({
+        exitCode: code,
+        output: outBuffer.toString()
+      })
+      resolve({
+        exitCode: code,
+        output: outBuffer.toString()
+      })
+    })
+  })
+}

--- a/spec/jasmine-ts.spec.ts
+++ b/spec/jasmine-ts.spec.ts
@@ -182,10 +182,6 @@ function testJasmine(args: string[] = [], cwd?: string): Promise<any> {
     })
 
     instance.on('close', code => {
-      console.log({
-        exitCode: code,
-        output: outBuffer.toString()
-      })
       resolve({
         exitCode: code,
         output: outBuffer.toString()

--- a/spec/jasmine-ts.spec.ts
+++ b/spec/jasmine-ts.spec.ts
@@ -84,6 +84,14 @@ describe("jasmine-ts", () => {
     expect(result.output).toContain('1 spec, 0 failures')
   })
 
+  it('should work with --transpile-only', async () => {
+    const cwd = path.join(__dirname, 'test-cases', 'transpile-only')
+
+    const result = await testJasmine(['--transpile-only', 'index.spec.ts'], cwd);
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain('1 spec, 0 failures')
+  })
+
   it('should work with --color', async () => {
     const cwd = path.join(__dirname, 'test-cases', 'simple-ts-file')
 

--- a/spec/test-cases/compiler-options/index.spec.ts
+++ b/spec/test-cases/compiler-options/index.spec.ts
@@ -1,0 +1,7 @@
+import * as sample from './sample.js'
+
+describe('project', () => {
+  it('should work', () => {
+    expect(sample).toBeTrue()
+  })
+})

--- a/spec/test-cases/compiler-options/sample.js
+++ b/spec/test-cases/compiler-options/sample.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/spec/test-cases/compiler-options/tsconfig.json
+++ b/spec/test-cases/compiler-options/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ESNext",
+    "strict": true,
+    "outDir": "lib"
+  }
+}

--- a/spec/test-cases/fail-fast/custom-reporter.js
+++ b/spec/test-cases/fail-fast/custom-reporter.js
@@ -1,0 +1,3 @@
+const { SpecReporter } = require('jasmine-spec-reporter')
+
+module.exports = SpecReporter

--- a/spec/test-cases/fail-fast/index.spec.ts
+++ b/spec/test-cases/fail-fast/index.spec.ts
@@ -1,0 +1,9 @@
+describe('fail-fast', () => {
+  it('should fail', () => {
+    expect(true).toBeFalse()
+  })
+
+  it('should pass', () => {
+    expect(true).toBeTrue()
+  })
+})

--- a/spec/test-cases/fail-fast/jasmine.json
+++ b/spec/test-cases/fail-fast/jasmine.json
@@ -1,0 +1,3 @@
+{
+  "random": false
+}

--- a/spec/test-cases/jasmine-json/jasmine.json
+++ b/spec/test-cases/jasmine-json/jasmine.json
@@ -1,0 +1,19 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.ts"
+  ],
+  "helpers": [
+    "helpers/**/*.ts"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false,
+  "reporters": [
+    {
+      "name": "jasmine-spec-reporter#SpecReporter",
+      "options": {
+        "displayStacktrace": "all"
+      }
+    }
+  ]
+}

--- a/spec/test-cases/jasmine-json/spec/index.spec.ts
+++ b/spec/test-cases/jasmine-json/spec/index.spec.ts
@@ -1,0 +1,5 @@
+describe('jasmine-json', () => {
+  it('should work', () => {
+    expect(true).toBeTrue()
+  })
+})

--- a/spec/test-cases/project/index.spec.ts
+++ b/spec/test-cases/project/index.spec.ts
@@ -1,0 +1,7 @@
+import * as sample from './sample.js'
+
+describe('project', () => {
+  it('should work', () => {
+    expect(sample).toBeTrue()
+  })
+})

--- a/spec/test-cases/project/sample.js
+++ b/spec/test-cases/project/sample.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/spec/test-cases/project/sub-dir/tsconfig.json
+++ b/spec/test-cases/project/sub-dir/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ESNext",
+    "strict": true,
+    "outDir": "lib",
+    "allowJs": true,
+    "checkJs": false,
+  }
+}

--- a/spec/test-cases/reporter/custom-reporter.js
+++ b/spec/test-cases/reporter/custom-reporter.js
@@ -1,0 +1,3 @@
+const { SpecReporter } = require('jasmine-spec-reporter')
+
+module.exports = SpecReporter

--- a/spec/test-cases/reporter/index.spec.ts
+++ b/spec/test-cases/reporter/index.spec.ts
@@ -1,0 +1,5 @@
+describe('--reporter', () => {
+  it('should work', () => {
+    expect(true).toBeTrue()
+  })
+})

--- a/spec/test-cases/require/.env
+++ b/spec/test-cases/require/.env
@@ -1,0 +1,1 @@
+___DOT_ENV_PARAM___=true

--- a/spec/test-cases/require/file-and-node_module.spec.ts
+++ b/spec/test-cases/require/file-and-node_module.spec.ts
@@ -1,0 +1,6 @@
+describe('--require with file', () => {
+  it('should work', () => {
+    expect(process.env.___REQUIRE_FILE_ENV___).toBe('req-value')
+    expect(process.env.___DOT_ENV_PARAM___).toBe('true')
+  })
+})

--- a/spec/test-cases/require/file.spec.ts
+++ b/spec/test-cases/require/file.spec.ts
@@ -1,0 +1,5 @@
+describe('--require with file', () => {
+  it('should work', () => {
+    expect(process.env.___REQUIRE_FILE_ENV___).toBe('req-value')
+  })
+})

--- a/spec/test-cases/require/node_module.spec.ts
+++ b/spec/test-cases/require/node_module.spec.ts
@@ -1,0 +1,5 @@
+describe('--require with node_module', () => {
+  it('should work', () => {
+    expect(process.env.___DOT_ENV_PARAM___).toBe('true')
+  })
+})

--- a/spec/test-cases/require/require-file.js
+++ b/spec/test-cases/require/require-file.js
@@ -1,0 +1,1 @@
+process.env.___REQUIRE_FILE_ENV___ = 'req-value'

--- a/spec/test-cases/simple-js-file/index.js
+++ b/spec/test-cases/simple-js-file/index.js
@@ -1,0 +1,5 @@
+describe('simple-js-file', () => {
+  it('should work', () => {
+    expect(true).toBeTrue()
+  })
+})

--- a/spec/test-cases/simple-ts-file/index.ts
+++ b/spec/test-cases/simple-ts-file/index.ts
@@ -1,0 +1,5 @@
+describe('simple-ts-file', () => {
+  it('should work', () => {
+    expect(true).toBeTrue()
+  })
+})

--- a/spec/test-cases/stop-on-failure/custom-reporter.js
+++ b/spec/test-cases/stop-on-failure/custom-reporter.js
@@ -1,0 +1,3 @@
+const { SpecReporter } = require('jasmine-spec-reporter')
+
+module.exports = SpecReporter

--- a/spec/test-cases/stop-on-failure/index.spec.ts
+++ b/spec/test-cases/stop-on-failure/index.spec.ts
@@ -1,0 +1,17 @@
+describe('stop-on-failure', () => {
+  let counter = 0;
+  beforeEach(() => {
+    if(counter === 0) {
+      fail('fake-error')
+      counter++;
+    }
+  })
+
+  it('test case 1', () => {
+    expect(true).toBeTrue()
+  })
+
+  it('test case 2', () => {
+    expect(true).toBeTrue()
+  })
+})

--- a/spec/test-cases/stop-on-failure/jasmine.json
+++ b/spec/test-cases/stop-on-failure/jasmine.json
@@ -1,0 +1,3 @@
+{
+  "random": false
+}

--- a/spec/test-cases/transpile-only/index.spec.ts
+++ b/spec/test-cases/transpile-only/index.spec.ts
@@ -1,0 +1,13 @@
+interface testInterface {
+  prop1: string;
+}
+
+describe('simple-ts-file', () => {
+  it('should work', () => {
+    const testInstance: testInterface = {
+      prop1: 1
+    }
+
+    expect(testInstance.prop1).toBe(1)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ const TS_NODE_OPTIONS = [
   "pretty",
   "skipProject",
   "skipIgnore",
-  "preferTsTxts",
+  "preferTsExts",
   "logError"
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,32 +1,141 @@
 #!/usr/bin/env node
 import * as path from "path";
-import { parse, register } from "ts-node";
-import { argv } from "yargs";
+import {parse, register} from "ts-node";
+import * as yargs from "yargs";
+
+const argv = yargs
+  .scriptName('jasmine-ts')
+  .usage('$0 [options]')
+  .option('r', {
+    alias: 'require',
+    describe: 'Require a node module before execution',
+  })
+  .option('T', {
+    alias: 'transpile-only',
+    type: 'boolean',
+    default: false,
+    describe: '[ts-node] Use TypeScript\'s faster `transpileModule`'
+  })
+  .option('I', {
+    alias: 'ignore',
+    describe: '[ts-node] Override the path patterns to skip compilation'
+  })
+  .option('P', {
+    alias: 'project',
+    describe: '[ts-node] Path to TypeScript JSON project file'
+  })
+  .option('C', {
+    alias: 'compiler',
+    describe: '[ts-node] Specify a custom TypeScript compiler'
+  })
+  .option('D', {
+    alias: 'ignore-diagnostics',
+    describe: '[ts-node] Ignore TypeScript warnings by diagnostic code'
+  })
+  .option('O', {
+    alias: 'compiler-options',
+    describe: '[ts-node] JSON object to merge with compiler options'
+  })
+  .option('dir', {
+    describe: '[ts-node] Specify working directory for config resolution'
+  })
+  .option('scope', {
+    describe: '[ts-node] Scope compiler to files within `cwd` only'
+  })
+  .option('files', {
+    describe: '[ts-node] Load `files`, `include` and `exclude` from `tsconfig.json` on startup'
+  })
+  .option('pretty', {
+    describe: '[ts-node] Use pretty diagnostic formatter (usually enabled by default)'
+  })
+  .option('skip-project', {
+    describe: '[ts-node] Skip reading `tsconfig.json`'
+  })
+  .option('skip-ignore', {
+    describe: '[ts-node] Skip `--ignore` checks'
+  })
+  .option('prefer-ts-exts', {
+    describe: '[ts-node] Prefer importing TypeScript files over JavaScript files'
+  })
+  .option('log-error', {
+    describe: '[ts-node] Logs TypeScript errors to stderr instead of throwing exceptions'
+  })
+  .option('no-color', {
+    describe: '[jasmine] Turn off color in spec output',
+    type: 'boolean'
+  })
+  .option('color', {
+    describe: '[jasmine] Force turn on color in spec output',
+    type: 'boolean'
+  })
+  .option('filter', {
+    describe: '[jasmine] Filter specs to run only those that match the given string'
+  })
+  .option('helper', {
+    describe: '[jasmine] Load helper files that match the given string'
+  })
+  .option('stop-on-failure', {
+    describe: '[jasmine] Stop spec execution on expectation failure',
+    type: 'boolean'
+  })
+  .option('fail-fast', {
+    describe: '[jasmine] Stop Jasmine execution on spec failure',
+    type: 'boolean'
+  })
+  .option('config', {
+    describe: '[jasmine] Path to your optional jasmine.json'
+  })
+  .option('reporter', {
+    describe: '[jasmine] Path to reporter to use instead of the default Jasmine reporter'
+  })
+  .option('random', {
+    describe: '[jasmine] Tells jasmine to run specs in semi random order or not for this run, overriding',
+    type: 'boolean'
+  })
+  .option('seed', {
+    describe: '[jasmine] TSets the randomization seed if randomization is turned on',
+    type: 'number'
+  })
+  .alias('h', 'help')
+  .alias('v', 'version')
+  .help()
+  .argv;
 
 const TS_NODE_OPTIONS = [
-  "fast",
-  "lazy",
-  "cache",
-  "cacheDirectory",
-  "compiler",
-  "project",
-  "ignore",
-  "ignoreWarnings",
-  "disableWarnings",
-  "getFile",
-  "fileExists",
-  "compilerOptions",
+  'require',
   "transpileOnly",
-  "typeCheck",
+  "ignore",
+  "project",
+  "compiler",
+  "ignoreDiagnostics",
+  "compilerOptions",
+  "dir",
+  "scope",
+  "files",
+  "pretty",
+  "skipProject",
+  "skipIgnore",
+  "preferTsTxts",
+  "logError"
 ];
 
-const tsNodeOptions = Object.assign({}, ...TS_NODE_OPTIONS.map((option) => {
+const tsNodeOptions = TS_NODE_OPTIONS.reduce((options, option) => {
   if (argv[option]) {
-    return (option === "compilerOptions")
-      ? {compilerOptions: parse(argv[option] as string)}
-      : {[option]: argv[option]};
+    if (option === "compilerOptions") {
+      options[option] = parse(argv[option] as string)
+    } else if (option === 'require') {
+      if (Array.isArray(argv[option])) {
+        options[option] = argv[option]
+      } else {
+        options[option] = [argv[option]]
+      }
+    } else {
+      options[option] = argv[option]
+    }
   }
-}));
+
+  return options;
+}, {} as any)
 
 register(tsNodeOptions);
 
@@ -38,24 +147,55 @@ const examplesDir = path.join("node_modules", "jasmine-core", "lib", "jasmine-co
 const command = new Command(path.resolve(), examplesDir, console.log);
 
 const JASMINE_OPTIONS = [
-  '--no-color',
-  '--color',
-  '--filter=',
-  '--helper=',
-  '--require=',
-  '--stop-on-failure=',
-  '--fail-fast=',
-  '--config=',
-  '--reporter='
+  'no-color',
+  'color',
+  'filter',
+  'helper',
+  'stop-on-failure',
+  'fail-fast',
+  'config',
+  'reporter',
+  'random',
+  'seed'
 ]
 
-function jasmineOptionsFilter(argOption: string): boolean {
-  return JASMINE_OPTIONS.some(option => argOption.startsWith(option))
-    || !argOption.startsWith('--');
+const commandOptions = JASMINE_OPTIONS
+  .filter(option => option in argv)
+  .map(option => {
+    switch (option) {
+      case 'color':
+        return argv.color ? '--color' : '--no-color'
+
+      case 'no-color':
+        return argv['no-color'] ? '--no-color' : undefined;
+
+      case 'stop-on-failure':
+        return argv['stop-on-failure'] ? '--stop-on-failure=true' : '--stop-on-failure=false'
+
+      case 'fail-fast':
+        return argv['fail-fast'] ? '--fail-fast=true' : '--fail-fast=false'
+
+      case 'random':
+        return argv.random? '--random=true' : '--random=false'
+
+      default:
+        return `--${option}=${argv[option]}`
+    }
+  })
+  .filter(option => option !== undefined)
+
+const files: string[] = [];
+
+console.log('argv._', argv._)
+for (const arg of argv._) {
+  if (typeof arg === 'string') {
+    if (arg.startsWith('-'))
+      break;
+
+    files.push(arg)
+  } else
+    files.push(arg.toString())
 }
 
-const commandOptions = process.argv
-  .slice(2)
-  .filter(jasmineOptionsFilter)
-
-command.run(jasmine, commandOptions);
+console.log({commandOptions, files})
+command.run(jasmine, [...commandOptions, ...files]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,6 @@ const commandOptions = JASMINE_OPTIONS
 
 const files: string[] = [];
 
-console.log('argv._', argv._)
 for (const arg of argv._) {
   if (typeof arg === 'string') {
     if (arg.startsWith('-'))
@@ -197,5 +196,4 @@ for (const arg of argv._) {
     files.push(arg.toString())
 }
 
-console.log({commandOptions, files})
 command.run(jasmine, [...commandOptions, ...files]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
         "strict": true,
         "sourceMap": true,
         "inlineSources": true,
-        "outDir": "lib"
+        "outDir": "lib",
     },
     "files": [
       "src/index.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
         "strict": true,
         "sourceMap": true,
         "inlineSources": true,
-        "outDir": "lib",
+        "outDir": "lib"
     },
     "files": [
       "src/index.ts"


### PR DESCRIPTION
More strict parameter validation. Mainly support `ts-node` > `9.x` and `jasmine` > `3.6.x`

- add `--help` CLI argument to display help
- `ts-node` parameter changes
  - removed parameters: `cache`, `cache-directory`, `disable-warnings`, `fast`, `file-exists`,  `ignore-warnings`, `lazy`, `type-check`
  - added parameters: `ignore-diagnostics`, `dir`, `scope`, `files`, `pretty`, `skip-project`, `skip-ignore`, `prefer-ts-exts`, `log-error`
- `jasmine` parameter changes
  - added parameters: `random`, `seed` 